### PR TITLE
Make custom display for date ranges

### DIFF
--- a/revenue_app/templates/revenue_app/_dynamic_table.html
+++ b/revenue_app/templates/revenue_app/_dynamic_table.html
@@ -1,3 +1,5 @@
+{% load date_filters %}
+
 <table class="table table-hover table-sm">
     <thead>
         <tr>
@@ -11,7 +13,31 @@
         <tr>
             {% for key, value in transaction.items %}
                 {% if key == 'transaction_created_date' %}
-                    <td><a href="{% url 'organizers-transactions' %}?start_date={{value|date:'Y-m-d'}}">{{value|date}}</a></td>
+                    {% if request.GET.groupby == 'week' %}
+                        <td><a href="{% url 'organizers-transactions' %}?start_date={{value|week_start|date:'Y-m-d'}}&end_date={{value|date:'Y-m-d'}}">
+                            from {{value|week_start|date}}<br/>to {{value|date}}
+                        </a></td>
+                    {% elif request.GET.groupby == 'semi-month' %}
+                        <td><a href="{% url 'organizers-transactions' %}?start_date={{value|date:'Y-m-d'}}&end_date={{value|semimonth_end|date:'Y-m-d'}}">
+                            from {{value|date}}<br/>to {{value|semimonth_end|date}}
+                        </a></td>
+                    {% elif request.GET.groupby == 'month' %}
+                        <td><a href="{% url 'organizers-transactions' %}?start_date={{value|date:'Y-m'}}-01&end_date={{value|date:'Y-m-d'}}">
+                            {{value|date:'F, Y'}}
+                        </a></td>
+                    {% elif request.GET.groupby == 'quarter' %}
+                        <td><a href="{% url 'organizers-transactions' %}?start_date={{value|quarter_start|date:'Y-m-d'}}&end_date={{value|date:'Y-m-d'}}">
+                            Q{{value|quarter}}
+                        </a></td>
+                    {% elif request.GET.groupby == 'year' %}
+                        <td><a href="{% url 'organizers-transactions' %}?start_date={{value.year}}-01-01&end_date={{value|date:'Y-m-d'}}">
+                            {{value.year}}
+                        </a></td>
+                    {% else %}
+                        <td><a href="{% url 'organizers-transactions' %}?start_date={{value|date:'Y-m-d'}}">
+                            {{value|date}}
+                        </a></td>
+                    {% endif %}
                 {% elif key in 'eventholder_user_id,email' %}
                     <td><a href="{% url 'organizer-transactions' organizer_id=transaction.eventholder_user_id %}">{{value}}</a></td>
                 {% elif key == 'event_id' %}

--- a/revenue_app/templates/revenue_app/_sidebar.html
+++ b/revenue_app/templates/revenue_app/_sidebar.html
@@ -13,12 +13,12 @@
             <form method="get" action="{% url 'transactions-grouped' %}">
                 <select id="groupby-select" name="groupby">
                     <option value="">--------</option>
-                    <option value="daily">Daily</option>
-                    <option value="weekly">Weekly</option>
-                    <option value="semi-monthly">Semi-Monthly</option>
-                    <option value="monthly">Monthly</option>
-                    <option value="quarterly">Quarterly</option>
-                    <option value="yearly">Yearly</option>
+                    <option value="day">Day</option>
+                    <option value="week">Week</option>
+                    <option value="semi-month">Semi-Month</option>
+                    <option value="month">Month</option>
+                    <option value="quarter">Quarter</option>
+                    <option value="year">Year</option>
                     <option value="eventholder_user_id">Organizer ID</option>
                     <option value="email">Organizer Email</option>
                     <option value="event_id">Events</option>

--- a/revenue_app/templatetags/date_filters.py
+++ b/revenue_app/templatetags/date_filters.py
@@ -1,0 +1,29 @@
+from calendar import monthrange
+from django import template
+from datetime import date, timedelta
+
+register = template.Library()
+
+
+@register.filter(name='week_start')
+def substract_date(value):
+    return (value - timedelta(days=6))
+
+
+@register.filter(name='semimonth_end')
+def get_semimonth_end(value):
+    if value.day < 15:
+        end_day = 14
+    else:
+        end_day = monthrange(value.year, value.month)[1]
+    return date(value.year, value.month, end_day)
+
+
+@register.filter(name='quarter')
+def get_quarter(value):
+    return (value.month - 1)//3 + 1
+
+
+@register.filter(name='quarter_start')
+def get_quarter_start(value):
+    return date(value.year, (value.month - 1) // 3 * 3 + 1, 1)

--- a/revenue_app/utils.py
+++ b/revenue_app/utils.py
@@ -87,12 +87,12 @@ def merge_transactions(transactions, organizer_sales):
 
 def group_transactions(transactions, by):
     time_groupby = {
-        'daily': 'D',
-        'weekly': 'W',
-        'semi-monthly': 'SMS',  # quincena
-        'monthly': 'M',
-        'quarterly': 'Q',  # trimestre
-        'yearly': 'Y',
+        'day': 'D',
+        'week': 'W',
+        'semi-month': 'SMS',  # quincena del 1 al 14 y del 15 a fin de mes, consultar con finanzas
+        'month': 'M',
+        'quarter': 'Q',  # trimestre
+        'year': 'Y',
     }
     custom_groupby = {
         'event_id': ['eventholder_user_id', 'email', 'event_id', 'currency'],


### PR DESCRIPTION
If you grouped transactions by some date frequency, it wasn't clear enough about what is showing. For example, if you grouped by week, it showed 'Aug. 4, 2019', but you didn't know if that was the first day of the week or the last day of the week.

**Now** it shows the date range (i.e. 'from July 29, 2019 to Aug. 4, 2019). Links now work that way too.