### PR TITLE
Replace date select for a date picker

### DIFF
--- a/revenue_app/static/revenue_app/css/base.css
+++ b/revenue_app/static/revenue_app/css/base.css
@@ -53,7 +53,7 @@ body {
 
 /* Sidebar */
 #sidebar-wrapper {
-  min-width: 150px;
+  min-width: 220px;
   transition: all 0.4s;
   overflow: hidden;
   flex: 1;

--- a/revenue_app/templates/revenue_app/_dynamic_table.html
+++ b/revenue_app/templates/revenue_app/_dynamic_table.html
@@ -34,7 +34,7 @@
                             {{value.year}}
                         </a></td>
                     {% else %}
-                        <td><a href="{% url 'organizers-transactions' %}?start_date={{value|date:'Y-m-d'}}">
+                        <td><a href="{% url 'organizers-transactions' %}?start_date={{value|date:'Y-m-d'}}&end_date={{value|date:'Y-m-d'}}">
                             {{value|date}}
                         </a></td>
                     {% endif %}

--- a/revenue_app/templates/revenue_app/_sidebar.html
+++ b/revenue_app/templates/revenue_app/_sidebar.html
@@ -32,18 +32,8 @@
           Filter by date
             <form method="get">
                 <input type="hidden" name="groupby" value="{{request.GET.groupby}}">
-                <select name="start_date">
-                    <option value=""></option>
-                    {% for date in dates_list %}
-                    <option value="{{ date }}">{{ date }}</option>
-                    {% endfor %}
-                </select>
-                <select name="end_date">
-                    <option value=""></option>
-                    {% for date in dates_list %}
-                    <option value="{{ date }}">{{ date }}</option>
-                    {% endfor %}
-                </select>
+                <input type="date" class="form-control" name="start_date" value={{request.GET.start_date}}>
+                <input type="date" class="form-control" name="end_date" value={{request.GET.end_date}}>
                 {% csrf_token %}
                 <button type="submit" class="mt-1 btn btn-evb-orange btn-sm">Apply</button>
             </form>

--- a/revenue_app/tests.py
+++ b/revenue_app/tests.py
@@ -19,7 +19,6 @@ from parameterized import parameterized
 from .utils import (
     calc_perc_take_rate,
     filter_transactions,
-    get_dates,
     get_organizer_sales,
     get_transactions,
     get_transactions_event,
@@ -248,12 +247,6 @@ class UtilsTestCase(TestCase):
         self.assertIsInstance(organizer_transactions, DataFrame)
         self.assertEqual(len(organizer_transactions), expected_length)
 
-    def test_get_dates(self):
-        with patch('pandas.read_csv', return_value=read_csv(TRANSACTIONS_EXAMPLE_PATH)):
-            dates = get_dates()
-        self.assertIsInstance(dates, list)
-        self.assertEqual(len(dates), 12)
-
     @parameterized.expand([
         ('66220941', 5, 3500),
         ('98415193', 6, 3402),
@@ -396,8 +389,7 @@ class ViewsTest(TestCase):
 
     def test_dashboard_view_returns_200_when_logged(self):
         URL = reverse('dashboard')
-        with patch('pandas.read_csv', return_value=read_csv(TRANSACTIONS_EXAMPLE_PATH)):
-            response = self.logged_client.get(URL)
+        response = self.logged_client.get(URL)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.template_name[0], Dashboard.template_name)
 
@@ -423,7 +415,6 @@ class ViewsTest(TestCase):
         URL = reverse('organizers-transactions')
         with patch('pandas.read_csv', side_effect=(
             read_csv(TRANSACTIONS_EXAMPLE_PATH),
-            read_csv(TRANSACTIONS_EXAMPLE_PATH),
             read_csv(ORGANIZER_SALES_EXAMPLE_PATH),
         )):
             response = self.logged_client.get(URL, kwargs)
@@ -448,7 +439,6 @@ class ViewsTest(TestCase):
     def test_organizer_transactions_view_returns_200_when_logged(self, eventholder_user_id, expected_length):
         URL = reverse('organizer-transactions', kwargs={'organizer_id': eventholder_user_id})
         with patch('pandas.read_csv', side_effect=(
-            read_csv(TRANSACTIONS_EXAMPLE_PATH),
             read_csv(TRANSACTIONS_EXAMPLE_PATH),
             read_csv(ORGANIZER_SALES_EXAMPLE_PATH),
             read_csv(TRANSACTIONS_EXAMPLE_PATH),
@@ -478,7 +468,6 @@ class ViewsTest(TestCase):
         URL = '{}?email={}'.format(reverse('transactions-search'), email)
         with patch('pandas.read_csv', side_effect=(
             read_csv(TRANSACTIONS_EXAMPLE_PATH),
-            read_csv(TRANSACTIONS_EXAMPLE_PATH),
             read_csv(ORGANIZER_SALES_EXAMPLE_PATH),
         )):
             response = self.logged_client.get(URL)
@@ -495,7 +484,6 @@ class ViewsTest(TestCase):
         URL = reverse('top-organizers')
         with patch('pandas.read_csv', side_effect=(
             read_csv(TRANSACTIONS_EXAMPLE_PATH),
-            read_csv(TRANSACTIONS_EXAMPLE_PATH),
             read_csv(ORGANIZER_SALES_EXAMPLE_PATH),
         )):
             response = self.logged_client.get(URL)
@@ -511,7 +499,6 @@ class ViewsTest(TestCase):
     def test_top_events_view_returns_200_when_logged(self):
         URL = reverse('top-events')
         with patch('pandas.read_csv', side_effect=(
-            read_csv(TRANSACTIONS_EXAMPLE_PATH),
             read_csv(TRANSACTIONS_EXAMPLE_PATH),
             read_csv(ORGANIZER_SALES_EXAMPLE_PATH),
         )):
@@ -538,14 +525,11 @@ class ViewsTest(TestCase):
         URL = reverse('event-details', kwargs={'event_id': event_id})
         with patch('pandas.read_csv', side_effect=(
             read_csv(TRANSACTIONS_EXAMPLE_PATH),
-            read_csv(TRANSACTIONS_EXAMPLE_PATH),
             read_csv(ORGANIZER_SALES_EXAMPLE_PATH),
             read_csv(ORGANIZER_SALES_EXAMPLE_PATH),
             read_csv(TRANSACTIONS_EXAMPLE_PATH),
             read_csv(ORGANIZER_SALES_EXAMPLE_PATH),
             read_csv(ORGANIZER_SALES_EXAMPLE_PATH),
-
-
         )):
             response = self.logged_client.get(URL)
         self.assertEqual(response.status_code, 200)
@@ -562,7 +546,6 @@ class ViewsTest(TestCase):
         kwargs = {'groupby': 'day'}
         URL = reverse('transactions-grouped')
         with patch('pandas.read_csv', side_effect=(
-            read_csv(TRANSACTIONS_EXAMPLE_PATH),
             read_csv(TRANSACTIONS_EXAMPLE_PATH),
             read_csv(ORGANIZER_SALES_EXAMPLE_PATH),
         )):

--- a/revenue_app/utils.py
+++ b/revenue_app/utils.py
@@ -3,29 +3,6 @@ import numpy as np
 import pandas as pd
 from random import randint
 
-FULL_COLUMNS = [
-    'eventholder_user_id',
-    'transaction_created_date',
-    'payment_processor',
-    'currency',
-    # Vertical (not found yet)
-    # Subvertical (not found yet)
-    'event_id',
-    'email',
-    'sale__payment_amount__epp',
-    'sale__gtf_esf__epp',
-    'sale__eb_tax__epp',
-    'sale__ap_organizer__gts__epp',
-    'sale__ap_organizer__royalty__epp',
-    'sale__gtf_esf__offline',
-    'refund__payment_amount__epp',
-    'refund__gtf_epp__gtf_esf__epp',
-    'refund__eb_tax__epp',
-    'refund__ap_organizer__gts__epp',
-    'sales_flag',
-    'eb_perc_take_rate',
-    # 'refund__ap_organizer__royalty__epp', (not found yet)
-]
 
 NUMBER_COLUMNS = [
     'sale__payment_amount__epp',
@@ -39,45 +16,6 @@ NUMBER_COLUMNS = [
     'refund__eb_tax__epp',
     'refund__ap_organizer__gts__epp',
     # 'eb_perc_take_rate',
-]
-
-ORGANIZER_FILTER_COLUMNS = [
-    'transaction_created_date',
-    'payment_processor',
-    'currency',
-    'event_id',
-    'eb_perc_take_rate',
-    'sale__payment_amount__epp',
-    'sale__gtf_esf__epp',
-    'sale__eb_tax__epp',
-    'sale__ap_organizer__gts__epp',
-    'sale__ap_organizer__royalty__epp',
-    'sale__gtf_esf__offline',
-    'refund__payment_amount__epp',
-    'refund__gtf_epp__gtf_esf__epp',
-    'refund__eb_tax__epp',
-    'refund__ap_organizer__gts__epp',
-]
-
-DATE_FILTER_COLUMNS = [
-    'transaction_created_date',
-    'email',
-    'sales_flag',
-    'payment_processor',
-    'currency',
-    'event_id',
-    'eb_perc_take_rate',
-    'sale__payment_amount__epp',
-    'sale__gtf_esf__epp',
-    'sale__eb_tax__epp',
-    'sale__ap_organizer__gts__epp',
-    'sale__ap_organizer__royalty__epp',
-    'sale__gtf_esf__offline',
-    'refund__payment_amount__epp',
-    'refund__gtf_epp__gtf_esf__epp',
-    'refund__eb_tax__epp',
-    'refund__ap_organizer__gts__epp',
-    # 'refund__ap_organizer__royalty__epp', (not found yet)
 ]
 
 
@@ -215,17 +153,6 @@ def get_transactions_event(event_id, **kwargs):
     return (transactions_event, paidtix, total)
 
 
-def get_dates():
-    transactions = get_transactions()
-    return np.datetime_as_string(
-        pd.to_datetime(
-            transactions['transaction_created_date'],
-            format="%Y-%m-%d",
-        ).sort_values().unique(),
-        unit='D',
-    ).tolist()
-
-
 def get_top_organizers(filtered_transactions):
     ordered = filtered_transactions.groupby(
         ['eventholder_user_id', 'email'],
@@ -251,6 +178,7 @@ def get_top_events(filtered_transactions):
 def random_color():
     return f"rgba({randint(0, 255)}, {randint(0, 255)}, {randint(0, 255)}, 0.2)"
 
+
 def summarize_dataframe(dataframe):
     dic = {}
     for column in dataframe.columns.tolist():
@@ -258,10 +186,13 @@ def summarize_dataframe(dataframe):
             dic[column] = dataframe[column].sum().round(2)
     return dic
 
+
 def organizer_details(organizer_id):
     details = {}
     organizer_transactions = transactions()
-    organizer_transactions = organizer_transactions[organizer_transactions['eventholder_user_id'] == organizer_id].head(1)
+    organizer_transactions = organizer_transactions[
+        organizer_transactions['eventholder_user_id'] == organizer_id
+    ].head(1)
     details['email'] = organizer_transactions['email'].to_string(index=False).strip()
     organizer_sales = get_organizer_sales()
     organizer_sales = organizer_sales[organizer_sales['email'] == details['email']]

--- a/revenue_app/views.py
+++ b/revenue_app/views.py
@@ -8,7 +8,6 @@ from django.http import HttpResponse
 from django.views.generic import TemplateView
 
 from .utils import (
-    get_dates,
     get_transactions_event,
     get_top_events,
     get_top_organizers,
@@ -110,18 +109,11 @@ EVENT_COLUMNS = [
 ]
 
 
-class TransactionsView(TemplateView):
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context['dates_list'] = get_dates()
-        return context
-
-
-class Dashboard(LoginRequiredMixin, TransactionsView):
+class Dashboard(LoginRequiredMixin, TemplateView):
     template_name = 'revenue_app/dashboard.html'
 
 
-class OrganizersTransactions(LoginRequiredMixin, TransactionsView):
+class OrganizersTransactions(LoginRequiredMixin, TemplateView):
     template_name = 'revenue_app/organizers_transactions.html'
 
     def get_context_data(self, **kwargs):
@@ -130,7 +122,7 @@ class OrganizersTransactions(LoginRequiredMixin, TransactionsView):
         return context
 
 
-class OrganizerTransactions(LoginRequiredMixin, TransactionsView):
+class OrganizerTransactions(LoginRequiredMixin, TemplateView):
     template_name = 'revenue_app/organizer_transactions.html'
 
     def get_context_data(self, *args, **kwargs):
@@ -146,7 +138,7 @@ class OrganizerTransactions(LoginRequiredMixin, TransactionsView):
         return context
 
 
-class TransactionsSearch(LoginRequiredMixin, TransactionsView):
+class TransactionsSearch(LoginRequiredMixin, TemplateView):
     template_name = 'revenue_app/organizer_transactions.html'
 
     def get_context_data(self, *args, **kwargs):
@@ -157,7 +149,7 @@ class TransactionsSearch(LoginRequiredMixin, TransactionsView):
         return context
 
 
-class TopOrganizersLatam(LoginRequiredMixin, TransactionsView):
+class TopOrganizersLatam(LoginRequiredMixin, TemplateView):
     template_name = 'revenue_app/top_organizers.html'
 
     def get_context_data(self, **kwargs):
@@ -168,7 +160,7 @@ class TopOrganizersLatam(LoginRequiredMixin, TransactionsView):
         return context
 
 
-class TransactionsEvent(LoginRequiredMixin, TransactionsView):
+class TransactionsEvent(LoginRequiredMixin, TemplateView):
     template_name = 'revenue_app/event.html'
 
     def get_context_data(self, **kwargs):
@@ -187,7 +179,7 @@ class TransactionsEvent(LoginRequiredMixin, TransactionsView):
         return context
 
 
-class TopEventsLatam(LoginRequiredMixin, TransactionsView):
+class TopEventsLatam(LoginRequiredMixin, TemplateView):
     template_name = 'revenue_app/top_events.html'
 
     def get_context_data(self, **kwargs):
@@ -198,7 +190,7 @@ class TopEventsLatam(LoginRequiredMixin, TransactionsView):
         return context
 
 
-class TransactionsGrouped(LoginRequiredMixin, TransactionsView):
+class TransactionsGrouped(LoginRequiredMixin, TemplateView):
     template_name = 'revenue_app/transactions_grouped.html'
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
The date filter selector was manually populated by the dates from the transactions (making a new query to the CSV). Now it just uses `<input type="date">` (but you can select dates not available in the CSV)