### PR TITLE
Change the query form to use a Django form and post

### DIFF
--- a/revenue_app/forms.py
+++ b/revenue_app/forms.py
@@ -1,0 +1,12 @@
+from django import forms
+
+
+class CustomDateInput(forms.DateInput):
+    input_type = 'date'
+
+
+class QueryForm(forms.Form):
+    okta_username = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-control'}))
+    okta_password = forms.CharField(widget=forms.PasswordInput(render_value=True, attrs={'class': 'form-control'}))
+    start_date = forms.DateField(widget=CustomDateInput(attrs={'class': 'form-control'}))
+    end_date = forms.DateField(widget=CustomDateInput(attrs={'class': 'form-control'}))

--- a/revenue_app/templates/revenue_app/query.html
+++ b/revenue_app/templates/revenue_app/query.html
@@ -30,36 +30,25 @@
   </div>
 </div>
 
-<form id="query-form" method="GET" action="{% url 'make-query' %}">
+<form id="query-form" method="POST" action="{% url 'make-query' %}">
   <div class="row">
+  {% for field in form.visible_fields %}
+    {% if field.field.widget.input_type in 'text,password' %}
     <div class="col-12">
       <div class="form-group">
-        <label for="okta_username">Okta Username:</label>
-        <input type="text" name="okta_username" class="form-control">
+        {{ field.label_tag }}
+        {{ field }}
       </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <div class="form-group">
-        <label for="okta_username">Okta Password:</label>
-        <input type="password" name="okta_password" class="form-control">
-      </div>
-    </div>
-  </div>
-  <div class="row">
+    {% elif field.field.widget.input_type == 'date' %}
     <div class="col-6">
       <div class="form-group">
-        <label for="start_date">Start date:</label>
-        <input type="date" name="start_date" class="form-control" value="{% previous_month_start %}">
+        {{ field.label_tag }}
+        {{ field }}
       </div>
     </div>
-    <div class="col-6">
-      <div class="form-group">
-        <label for="end_date">End date:</label>
-        <input type="date" name="end_date" class="form-control" value="{% previous_month_end %}">
-      </div>
-    </div>
+    {% endif %}
+  {% endfor %}
   </div>
   {% csrf_token %}
   <div class="row mt-3">

--- a/revenue_app/templatetags/date_filters.py
+++ b/revenue_app/templatetags/date_filters.py
@@ -1,7 +1,6 @@
 from calendar import monthrange
 from django import template
 from datetime import date, timedelta
-from dateutil.relativedelta import relativedelta
 
 register = template.Library()
 
@@ -28,16 +27,3 @@ def get_quarter(value):
 @register.filter(name='quarter_start')
 def get_quarter_start(value):
     return date(value.year, (value.month - 1) // 3 * 3 + 1, 1)
-
-
-@register.simple_tag(name='previous_month_start')
-def get_previous_month_start():
-    today = date.today()
-    new_date = today - relativedelta(months=1)
-    return date(new_date.year, new_date.month, 1)
-
-
-@register.simple_tag(name='previous_month_end')
-def get_previous_month_end():
-    today = date.today()
-    return date(today.year, today.month, 1) - relativedelta(days=1)


### PR DESCRIPTION
- Replace manual template form for a Django Form
- Replace GET for POST in form
- Modify QueryView as a TemplateView to be a FormView
- Delete unnecessary template filters, as they were used to initialize the form, and now the form is initialized in the View
- The tests for the template filters are modified to test the form initialization on the view