### PR TITLE
Add tooltip glosary about how the key is calculated

### DIFF
--- a/revenue_app/static/revenue_app/css/base.css
+++ b/revenue_app/static/revenue_app/css/base.css
@@ -212,3 +212,7 @@ footer a {
 #gif {
   color: #D1410C;
 }
+
+.tooltip-inner {
+  max-width: 300px;
+}

--- a/revenue_app/templates/revenue_app/_dynamic_table.html
+++ b/revenue_app/templates/revenue_app/_dynamic_table.html
@@ -1,4 +1,5 @@
 {% load date_filters %}
+{% load glossary_filters %}
 {% load number_filters %}
 {% load humanize %}
 <div class="container-fluid transactions-table">
@@ -6,7 +7,7 @@
         <thead>
             <tr class="text-center">
                 {% for header in transactions.columns %}
-                    <th scope="col">{{ header }}</th>
+                    <th data-toggle="tooltip" data-placement="top" title="{% glossary header %}" scope="col">{{ header }}</th>
                 {% endfor %}
             </tr>
         </thead>

--- a/revenue_app/templates/revenue_app/base.html
+++ b/revenue_app/templates/revenue_app/base.html
@@ -32,6 +32,12 @@
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->
     <!-- Bootstrap core JavaScript -->
     {% bootstrap_javascript jquery='full' %}
+    <!-- Enable Tooltips -->
+    <script type="text/javascript">
+      $(function () {
+        $('[data-toggle="tooltip"]').tooltip();
+      });
+    </script>
     <!-- Sidebar Toggle Script -->
     <script>
       $("#sidebar-toggle").click(function(e) {
@@ -58,14 +64,6 @@
       for (i=0; i<groupby_select.options.length; i++) {
         if (groupby_select.options[i].value == groupby_param) {
           groupby_select.selectedIndex = i;
-        }
-      }
-
-      var currency_select = document.getElementById("currency-select");
-      var currency_param = getURLParam('currency');
-      for (i=0; i<currency_select.options.length; i++) {
-        if (currency_select.options[i].value == currency_param) {
-          currency_select.selectedIndex = i;
         }
       }
     </script>

--- a/revenue_app/templates/revenue_app/dashboard.html
+++ b/revenue_app/templates/revenue_app/dashboard.html
@@ -1,6 +1,7 @@
 
 {% extends 'revenue_app/base.html' %}
 {% load static %}
+{% load glossary_filters %}
 {% load humanize %}
 
 {% block content %}
@@ -14,7 +15,7 @@
       <table class="table table-striped mt-4">
         {% for key, value in data.items %}
           <tr>
-            <td><b>{{key}}</b></td>
+            <td><b data-toggle="tooltip" data-placement="top" title="{% glossary key %}">{{key}}</b></td>
             <td class="text-right text-monospace">{{value|floatformat:2|intcomma}}</td>
           </tr>
         {% endfor %}

--- a/revenue_app/templates/revenue_app/event.html
+++ b/revenue_app/templates/revenue_app/event.html
@@ -1,5 +1,6 @@
 {% extends 'revenue_app/base.html' %}
 {% load static %}
+{% load glossary_filters %}
 {% load number_filters %}
 {% block content %}
 <div class="row m-0">
@@ -25,7 +26,7 @@
         <table class="table table-striped mt-4 table-sm">
         {% for key, value in details.items %}
             <tr>
-                <td class="summarized-key"><b>{{key}}</b></td>
+                <td class="summarized-key"><b data-toggle="tooltip" data-placement="top" title="{% glossary key %}">{{key}}</b></td>
                 {% if value|is_numeric %}
                 <td class="text-right text-monospace">{{value|floatformat:2}}</td>
                 {% else %}
@@ -41,7 +42,7 @@
             <table class="table table-striped table-sm mt-4">
                 {% for key, value in data.items %}
                 <tr>
-                    <td><b>{{key}}</b></td>
+                    <td><b data-toggle="tooltip" data-placement="top" title="{% glossary key %}">{{key}}</b></td>
                     <td class="text-right text-monospace">{{value|floatformat:2}}</td>
                 </tr>
                 {% endfor %}
@@ -56,7 +57,7 @@
         <table class="table table-striped table-sm mt-4">
             {% for key, value in data.items %}
             <tr>
-                <td><b>{{key}}</b></td>
+                <td><b data-toggle="tooltip" data-placement="top" title="{% glossary key %}">{{key}}</b></td>
                 <td class="text-right text-monospace">{{value|floatformat:2}}</td>
             </tr>
             {% endfor %}

--- a/revenue_app/templates/revenue_app/organizer_transactions.html
+++ b/revenue_app/templates/revenue_app/organizer_transactions.html
@@ -1,5 +1,6 @@
 {% extends 'revenue_app/base.html' %}
 {% load static %}
+{% load glossary_filters %}
 {% load number_filters %}
 {% block content %}
 <div class="row m-0">
@@ -25,7 +26,7 @@
         <table class="table table-striped mt-4 table-sm">
         {% for key, value in details.items %}
             <tr>
-                <td class="summarized-key"><b>{{key}}</b></td>
+                <td class="summarized-key"><b data-toggle="tooltip" data-placement="top" title="{% glossary key %}">{{key}}</b></td>
                 {% if value|is_numeric %}
                 <td class="text-right text-monospace">{{value|floatformat:2}}</td>
                 {% else %}
@@ -41,7 +42,7 @@
             <table class="table table-striped table-sm mt-4">
                 {% for key, value in data.items %}
                 <tr>
-                    <td><b>{{key}}</b></td>
+                    <td><b data-toggle="tooltip" data-placement="top" title="{% glossary key %}">{{key}}</b></td>
                     <td class="text-right text-monospace">{{value|floatformat:2}}</td>
                 </tr>
                 {% endfor %}
@@ -56,7 +57,7 @@
             <table class="table table-striped table-sm mt-4">
                 {% for key, value in data.items %}
                 <tr>
-                    <td><b>{{key}}</b></td>
+                    <td><b data-toggle="tooltip" data-placement="top" title="{% glossary key %}">{{key}}</b></td>
                     <td class="text-right text-monospace">{{value|floatformat:2}}</td>
                 </tr>
                 {% endfor %}

--- a/revenue_app/templatetags/glossary_filters.py
+++ b/revenue_app/templatetags/glossary_filters.py
@@ -1,0 +1,53 @@
+from django import template
+
+GLOSSARY = {
+    'transaction_created_date': 'from all queries',
+    'eventholder_user_id': 'from transactions query',
+    'Organizer ID': 'from transactions query',
+    'Organizer Name': 'from organizer sales/refunds queries',
+    'email': 'from all queries',
+    'Email': 'from all queries',
+    'sales_flag': 'from organizer sales/refunds queries',
+    'payment_processor': 'from organizer sales/refunds queries',
+    'currency': 'from transactions query',
+    'PaidTix': 'from organizer sales/refunds queries',
+    'sales_vertical': 'from organizer sales/refunds queries',
+    'vertical': 'from organizer sales/refunds queries',
+    'sub_vertical': 'from organizer sales/refunds queries',
+    'event_id': 'from all queries',
+    'Event ID': 'from all queries',
+    'event_title': 'from organizer sales/refunds queries',
+    'Event Title': 'from organizer sales/refunds queries',
+    'eb_perc_take_rate': 'sale__gtf_esf__epp / sale__payment_amount__epp * 100',
+    'sale__payment_amount__epp': 'from transactions query',
+    'sale__gtf_esf__epp': 'from transactions query',
+    'sale__eb_tax__epp': 'from transactions query',
+    'sale__ap_organizer__gts__epp': 'from transactions query',
+    'sale__ap_organizer__royalty__epp': 'from transactions query',
+    'refund__payment_amount__epp': 'from transactions query',
+    'refund__gtf_epp__gtf_esf__epp': 'from transactions query',
+    'refund__eb_tax__epp': 'from transactions query',
+    'refund__ap_organizer__gts__epp': 'from transactions query',
+    'refund__ap_organizer__royalty__epp': 'from transactions query',
+    'net__payment_amount__epp': 'sale__payment_amount__epp + refund__payment_amount__epp',
+    'net__gtf_esf__epp': 'sale__gtf_esf__epp + refund__gtf_epp__gtf_esf__epp',
+    'net__eb_tax__epp': 'sale__eb_tax__epp + refund__eb_tax__epp',
+    'net__ap_organizer__gts__epp': 'sale__ap_organizer__gts__epp + refund__ap_organizer__gts__epp',
+    'net__ap_organizer__royalty__epp': 'sale__ap_organizer__royalty__epp + refund__ap_organizer__royalty__epp',
+    'AVG Ticket Value': 'sale__payment_amount__epp / PaidTix',
+    'AVG PaidTix/Day':  'PaidTix / days quantity',
+    'Total Organizers': 'number of unique eventholder_user_id',
+    'Total Events': 'number of unique event_id',
+    'Total PaidTix': 'sum of PaidTix',
+    'Total GTF': 'sum of sale__gtf_esf__epp',
+    'Total GTV': 'sum of sale__payment_amount__epp',
+    'ATV': '(sum of sale__payment_amount__epp - sum of sale__gtf_esf__epp) / sum of PaidTix',
+    'Avg EB Perc Take Rate': 'sum of sale__gtf_esf__epp / sum of sale__payment_amount__epp * 100',
+}
+
+register = template.Library()
+
+
+@register.simple_tag(name='glossary')
+def get_key_from_glossary(key):
+    return GLOSSARY.get(key)

--- a/revenue_app/tests.py
+++ b/revenue_app/tests.py
@@ -303,7 +303,7 @@ class UtilsTestCase(TestCase):
         ('88128252', 7, 2405),
     ])
     def test_get_event_transactions(self, event_id, transactions_qty, tickets_qty):
-        transactions, details, sales_refunds, net_sales_refunds  = get_event_transactions(
+        transactions, details, sales_refunds, net_sales_refunds = get_event_transactions(
             self.transactions,
             self.corrections,
             self.organizer_sales,
@@ -1083,6 +1083,20 @@ class TemplateTagsTest(TestCase):
             '{% else %}'
             'Not number type.'
             '{% endif %}',
+            context
+        )
+        self.assertEqual(rendered, expected)
+
+    @parameterized.expand([
+        ({'key': 'invalid key'}, 'None'),
+        ({'key': 'eventholder_user_id'}, 'from transactions query'),
+        ({'key': 'eb_perc_take_rate'}, 'sale__gtf_esf__epp / sale__payment_amount__epp * 100'),
+        ({'key': 'net__ap_organizer__gts__epp'}, 'sale__ap_organizer__gts__epp + refund__ap_organizer__gts__epp'),
+    ])
+    def test_glossary(self, context, expected):
+        rendered = self.render_template(
+            '{% load glossary_filters %}'
+            '{% glossary key %}',
             context
         )
         self.assertEqual(rendered, expected)


### PR DESCRIPTION
- Enabled bootstrap tooltips
- Added a template simple tag to read the glossary. I chose that way because there is no 'native' way to access dict keys dynamically in templates. For example, you can't do `{{ dict[key] }}` or `{{ dict.get(key) }}`. You can do `dict.key`, but if the key is "dynamic" (like in a for) there is no way to access.