### PR TITLE
Validate dates in query form

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ coverage==4.5.4
 coveralls==1.8.2
 Django==1.11.24
 django-bootstrap4==1.0.1
+django-widget-tweaks==1.4.5
 docopt==0.6.2
 freezegun==0.3.12
 future==0.18.0

--- a/revenue_app/forms.py
+++ b/revenue_app/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from datetime import date, timedelta
 
 
 class CustomDateInput(forms.DateInput):
@@ -6,7 +7,31 @@ class CustomDateInput(forms.DateInput):
 
 
 class QueryForm(forms.Form):
-    okta_username = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-control'}))
-    okta_password = forms.CharField(widget=forms.PasswordInput(render_value=True, attrs={'class': 'form-control'}))
-    start_date = forms.DateField(widget=CustomDateInput(attrs={'class': 'form-control'}))
-    end_date = forms.DateField(widget=CustomDateInput(attrs={'class': 'form-control'}))
+    okta_username = forms.CharField(widget=forms.TextInput())
+    okta_password = forms.CharField(widget=forms.PasswordInput(render_value=True))
+    start_date = forms.DateField(widget=CustomDateInput())
+    end_date = forms.DateField(widget=CustomDateInput())
+
+    def clean(self):
+        cleaned_data = super().clean()
+        start_date = cleaned_data.get('start_date')
+        end_date = cleaned_data.get('end_date')
+
+        if start_date and end_date:
+            if end_date > date.today():
+                error = forms.ValidationError("End date can't be greater than today.")
+                self.add_error('end_date', error)
+
+            if start_date > date.today():
+                error = forms.ValidationError("Start date can't be greater than today.")
+                self.add_error('start_date', error)
+
+            if end_date < start_date:
+                error = forms.ValidationError('End date must be greater or equal than start date.')
+                self.add_error('start_date', error)
+                self.add_error('end_date', error)
+
+            if (end_date - start_date) > timedelta(days=92):
+                error = forms.ValidationError("Time between End and Start date can't be over 3 months.")
+                self.add_error('start_date', error)
+                self.add_error('end_date', error)

--- a/revenue_app/templates/revenue_app/query.html
+++ b/revenue_app/templates/revenue_app/query.html
@@ -2,6 +2,7 @@
 {% extends 'revenue_app/base.html' %}
 {% load static %}
 {% load date_filters %}
+{% load widget_tweaks %}
 
 {% block content %}
 
@@ -11,40 +12,66 @@
   </div>
 </div>
 
+{% if queries_status %}
 <div class="row">
   <div class="col-12">
-    {% if error %}
-      <div class="alert alert-danger">
-        {{ error|safe }}
-      </div>
-    {% elif queries_status %}
-      <div class="alert alert-success">
-        Successful queries:
-        <ul class="mb-0">
-        {% for status in queries_status %}
-          <li>{{ status }}</li>
-        {% endfor %}
-        </ul>
-      </div>
-    {% endif %}
+    <div class="alert alert-success">
+      Successful queries:
+      <ul class="mb-0">
+      {% for status in queries_status %}
+        <li>{{ status }}</li>
+      {% endfor %}
+      </ul>
+    </div>
   </div>
 </div>
+{% endif %}
 
 <form id="query-form" method="POST" action="{% url 'make-query' %}">
+  {% if form.non_field_errors %}
+  <div class="row">
+    <div class="col-12">
+      <div class="alert alert-danger" role="alert">
+      {% for error in form.non_field_errors %}
+        {{ error|safe }}
+      {% endfor %}
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
   <div class="row">
   {% for field in form.visible_fields %}
     {% if field.field.widget.input_type in 'text,password' %}
     <div class="col-12">
       <div class="form-group">
         {{ field.label_tag }}
-        {{ field }}
+        {% if field.errors %}
+          {% render_field field class="form-control is-invalid" %}
+          {% for error in field.errors %}
+            <div class="invalid-feedback">
+              {{ error }}
+            </div>
+          {% endfor %}
+        {% else %}
+          {% render_field field class="form-control" %}
+        {% endif %}
       </div>
     </div>
     {% elif field.field.widget.input_type == 'date' %}
     <div class="col-6">
       <div class="form-group">
         {{ field.label_tag }}
-        {{ field }}
+        {% if field.errors %}
+          {% render_field field class="form-control is-invalid" %}
+          {% for error in field.errors %}
+            <div class="invalid-feedback">
+              {{ error }}
+            </div>
+          {% endfor %}
+        {% else %}
+          {% render_field field class="form-control" %}
+        {% endif %}
       </div>
     </div>
     {% endif %}
@@ -63,7 +90,6 @@
         Running queries...
     </h6>
 </div>
-<br>
 {% endblock content %}
 {% block scripts %}
 <script type="text/javascript">

--- a/revenue_app/tests.py
+++ b/revenue_app/tests.py
@@ -951,6 +951,42 @@ class ViewsTest(TestCase):
         assert_frame_equal(self.client.session['transactions'], read_csv(TRANSACTIONS_EXAMPLE_PATH))
         assert_frame_equal(self.client.session['corrections'], read_csv(CORRECTIONS_EXAMPLE_PATH))
 
+    @parameterized.expand([
+        ({}, 'This field is required.'),
+        (
+            {
+                'okta_username': 'fakename',
+                'okta_password': 'fakepass',
+                'start_date': '2018-08-06',
+                'end_date': '2018-08-05',
+            },
+            'End date must be greater or equal than start date.',
+        ),
+        (
+            {
+                'okta_username': 'fakename',
+                'okta_password': 'fakepass',
+                'start_date': '2018-05-01',
+                'end_date': '2018-08-05',
+            },
+            'Time between End and Start date can&#39;t be over 3 months.',
+        ),
+        (
+            {
+                'okta_username': 'fakename',
+                'okta_password': 'fakepass',
+                'start_date': '2018-09-14',
+                'end_date': '2018-09-15',
+            },
+            "can&#39;t be greater than today.",
+        ),
+    ])
+    def test_make_query_form_validation(self, kwargs, error_message):
+        URL = reverse('make-query')
+        with freeze_time("2018-08-10"):
+            response = self.client.post(URL, kwargs)
+        self.assertContains(response, error_message)
+
 
 class TemplateTagsTest(TestCase):
     def render_template(self, string, context=None):

--- a/revenue_app/utils.py
+++ b/revenue_app/utils.py
@@ -41,7 +41,6 @@ NUMBER_COLUMNS = [
 ]
 
 
-
 def get_rollups():
     return pd.read_excel('datasets/Revenue Queries.xlsx', sheet_name=0, header=1, usecols=range(0, 53))
 
@@ -294,8 +293,12 @@ def get_event_transactions(transactions, corrections, organizer_sales, organizer
     }
     net_sales_refunds = {
         'Total Net Detail': {
-            net : sale + refund
-            for net, sale, refund in zip(NET_COLUMNS, sales_refunds['Total Sales Detail'].values(), sales_refunds['Total Refunds Detail'].values())
+            net: sale + refund
+            for net, sale, refund in zip(
+                NET_COLUMNS,
+                sales_refunds['Total Sales Detail'].values(),
+                sales_refunds['Total Refunds Detail'].values(),
+            )
         }
     }
     return filtered, details, sales_refunds, net_sales_refunds
@@ -340,8 +343,12 @@ def get_organizer_transactions(
     }
     net_sales_refunds = {
         'Total Net Detail': {
-            net : sale + refund
-            for net, sale, refund in zip(NET_COLUMNS, sales_refunds['Total Sales Detail'].values(), sales_refunds['Total Refunds Detail'].values())
+            net: sale + refund
+            for net, sale, refund in zip(
+                NET_COLUMNS,
+                sales_refunds['Total Sales Detail'].values(),
+                sales_refunds['Total Refunds Detail'].values(),
+            )
         }
     }
     return filtered, details, sales_refunds, net_sales_refunds

--- a/revenue_app/views.py
+++ b/revenue_app/views.py
@@ -198,15 +198,13 @@ class MakeQuery(FormView):
         initial['end_date'] = previous_month_end
         return initial
 
-    def post(self, request, *args, **kwargs):
-        form = self.get_form()
+    def form_valid(self, form):
         start_date = form.data.get('start_date')
         end_date = form.data.get('end_date')
         okta_username = form.data.get('okta_username')
         okta_password = form.data.get('okta_password')
 
         queries_status = []
-        error = ""
 
         for query_name in [
             'organizer_sales',
@@ -222,18 +220,17 @@ class MakeQuery(FormView):
                     okta_password=okta_password,
                     query_name=query_name,
                 )
-                request.session[query_name] = dataframe
+                self.request.session[query_name] = dataframe
                 queries_status.append(
                     f'{query_name} ran successfully.'
                 )
             except PrestoError as exception:
-                error = exception.args[0]
+                form.add_error(None, exception.args[0])
                 break
 
         return self.render_to_response(
             self.get_context_data(
                 queries_status=queries_status,
-                error=error,
                 form=form,
             )
         )
@@ -411,7 +408,7 @@ def top_organizers_json_data(request):
         request.session.get('organizer_sales'),
         request.session.get('organizer_refunds'),
     )
-    ids = list(range(0,11))
+    ids = list(range(0, 11))
     top_organizers_ars = get_top_organizers(trx[trx['currency'] == 'ARS'])
     ars_names = top_organizers_ars['email'].tolist()
     ars_quantities = top_organizers_ars['sale__gtf_esf__epp'].tolist()
@@ -442,7 +439,7 @@ def top_organizers_refunds_json_data(request):
         request.session.get('organizer_sales'),
         request.session.get('organizer_refunds'),
     )
-    ids = list(range(0,11))
+    ids = list(range(0, 11))
     top_organizers_ars = get_top_organizers_refunds(trx[trx['currency'] == 'ARS'])
     ars_names = top_organizers_ars['email'].tolist()
     ars_quantities = top_organizers_ars['refund__gtf_epp__gtf_esf__epp'].tolist()
@@ -473,7 +470,7 @@ def top_events_json_data(request):
         request.session.get('organizer_sales'),
         request.session.get('organizer_refunds'),
     )
-    ids = list(range(0,11))
+    ids = list(range(0, 11))
     top_events_ars = get_top_events(trx[trx['currency'] == 'ARS'])
     ars_names = [f'[{id}] {title[:20]}' for id, title in zip(top_events_ars['event_id'], top_events_ars['event_title'])]
     ars_quantities = top_events_ars['sale__gtf_esf__epp'].tolist()
@@ -504,7 +501,7 @@ def dashboard_summary(request):
         request.session.get('organizer_sales'),
         request.session.get('organizer_refunds'),
     )
-    ids = list(range(0,10))
+    ids = list(range(0, 10))
     ars = trx[trx['currency'] == 'ARS']
     brl = trx[trx['currency'] == 'BRL']
 

--- a/settings/base.py
+++ b/settings/base.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.humanize',
     'revenue_app',
     'bootstrap4',
+    'widget_tweaks',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
- Add validations in `QueryForm`
- Render field errors in template
- Replace overriding `post` for overriding `form_valid`, because default post validates the form first
- Replace `error` variable to use the `non_field_errors` from the `form`