### PR TITLE
Add net values to dashboard

### DIFF
--- a/revenue_app/templates/revenue_app/dashboard.html
+++ b/revenue_app/templates/revenue_app/dashboard.html
@@ -13,11 +13,20 @@
     <div class="row">
       <h4>{{currency}}</h4>
       <table class="table table-striped mt-4">
-        {% for key, value in data.items %}
-          <tr>
-            <td><b data-toggle="tooltip" data-placement="top" title="{% glossary key %}">{{key}}</b></td>
-            <td class="text-right text-monospace">{{value|floatformat:2|intcomma}}</td>
-          </tr>
+        {% for parent_key, parent_value in data.items %}
+        <tr>
+          <td class="align-middle" rowspan="{{ parent_value|length }}"><b>{{parent_key}}</b></td>
+          {% for child_key, child_value in parent_value.items %}
+            {% if not forloop.first %}
+              <tr>
+            {% endif %}
+            <td><b data-toggle="tooltip" data-placement="top" title="{% glossary parent_key|add:child_key %}">{{child_key}}</b></td>
+            <td class="text-right text-monospace">{{child_value|floatformat:2|intcomma}}</td>
+            {% if not forloop.first %}
+              </tr>
+            {% endif %}
+          {% endfor %}
+        </tr>
         {% endfor %}
       </table>
     </div>

--- a/revenue_app/templatetags/glossary_filters.py
+++ b/revenue_app/templatetags/glossary_filters.py
@@ -36,13 +36,19 @@ GLOSSARY = {
     'net__ap_organizer__royalty__epp': 'sale__ap_organizer__royalty__epp + refund__ap_organizer__royalty__epp',
     'AVG Ticket Value': 'sale__payment_amount__epp / PaidTix',
     'AVG PaidTix/Day':  'PaidTix / days quantity',
-    'Total Organizers': 'number of unique eventholder_user_id',
-    'Total Events': 'number of unique event_id',
-    'Total PaidTix': 'sum of PaidTix',
-    'Total GTF': 'sum of sale__gtf_esf__epp',
-    'Total GTV': 'sum of sale__payment_amount__epp',
-    'ATV': '(sum of sale__payment_amount__epp - sum of sale__gtf_esf__epp) / sum of PaidTix',
-    'Avg EB Perc Take Rate': 'sum of sale__gtf_esf__epp / sum of sale__payment_amount__epp * 100',
+    'TotalsOrganizers': 'number of unique eventholder_user_id',
+    'TotalsEvents': 'number of unique event_id',
+    'TotalsPaidTix': 'sum of PaidTix',
+    'NetGTF': 'sum of sale__gtf_esf__epp + refund__gtf_epp__gtf_esf__epp',
+    'NetGTV': 'sum of sale__payment_amount__epp + refund__payment_amount__epp',
+    'NetATV': 'sum of (sale__payment_amount__epp - sale__gtf_esf__epp'
+              ' + refund__payment_amount__epp - refund__gtf_epp__gtf_esf__epp) / sum of PaidTix',
+    'NetAvg EB Take Rate': 'sum of (sale__gtf_esf__epp + refund__gtf_epp__gtf_esf__epp) / '
+                           'sum of (sale__payment_amount__epp + refund__payment_amount__epp) * 100',
+    'SalesGTF': 'sum of sale__gtf_esf__epp',
+    'SalesGTV': 'sum of sale__payment_amount__epp',
+    'SalesATV': 'sum of (sale__payment_amount__epp - sale__gtf_esf__epp) / sum of PaidTix',
+    'SalesAvg EB Take Rate': 'sum of sale__gtf_esf__epp / sum of sale__payment_amount__epp * 100',
 }
 
 register = template.Library()

--- a/revenue_app/tests.py
+++ b/revenue_app/tests.py
@@ -511,29 +511,37 @@ class UtilsTestCase(TestCase):
         self.assertEqual(response, details_organizer)
 
     @parameterized.expand([
-        ('ARS', 'Total Organizers', 2),
-        ('ARS', 'Total Events', 2),
-        ('ARS', 'Total PaidTix', 12905),
-        ('ARS', 'Total GTF', 1480.49),
-        ('ARS', 'Total GTV', 22971.37),
-        ('ARS', 'ATV', 1.67),
-        ('ARS', 'Avg EB Perc Take Rate', 6.44),
-        ('BRL', 'Total Organizers', 3),
-        ('BRL', 'Total Events', 3),
-        ('BRL', 'Total PaidTix', 18225),
-        ('BRL', 'Total GTF', 954.0),
-        ('BRL', 'Total GTV', 12331.0),
-        ('BRL', 'ATV', 0.62),
-        ('BRL', 'Avg EB Perc Take Rate', 7.74),
+        ('ARS', 'Totals', 'Organizers', 2),
+        ('ARS', 'Totals', 'Events', 2),
+        ('ARS', 'Totals', 'PaidTix', 12905),
+        ('ARS', 'Sales', 'GTF', 1480.49),
+        ('ARS', 'Sales', 'GTV', 22971.37),
+        ('ARS', 'Sales', 'ATV', 1.67),
+        ('ARS', 'Sales', 'Avg EB Take Rate', 6.44),
+        ('ARS', 'Net', 'GTF', 1149.16),
+        ('ARS', 'Net', 'GTV', 17830.46),
+        ('ARS', 'Net', 'ATV', 1.29),
+        ('ARS', 'Net', 'Avg EB Take Rate', 6.44),
+        ('BRL', 'Totals', 'Organizers', 3),
+        ('BRL', 'Totals', 'Events', 3),
+        ('BRL', 'Totals', 'PaidTix', 18225),
+        ('BRL', 'Sales', 'GTF', 954.0),
+        ('BRL', 'Sales', 'GTV', 12331.0),
+        ('BRL', 'Sales', 'ATV', 0.62),
+        ('BRL', 'Sales', 'Avg EB Take Rate', 7.74),
+        ('BRL', 'Net', 'GTF', 563.55),
+        ('BRL', 'Net', 'GTV', 7359.0),
+        ('BRL', 'Net', 'ATV', 0.37),
+        ('BRL', 'Net', 'Avg EB Take Rate', 7.66),
     ])
-    def test_get_summarized_data(self, country, data, expected):
+    def test_get_summarized_data(self, country, group, data, expected):
         summarized_data = get_summarized_data(
             self.transactions,
             self.corrections,
             self.organizer_sales,
             self.organizer_refunds,
         )
-        self.assertEqual(summarized_data[country][data], expected)
+        self.assertEqual(summarized_data[country][group][data], expected)
 
     @parameterized.expand([
         ('ARS', 'ADYEN', 22971.37, 1480.49),
@@ -593,27 +601,35 @@ class ViewsTest(TestCase):
     def test_dashboard_view_returns_200(self):
         URL = reverse('dashboard')
         context_dict = [
-            ('ARS', 'Total Organizers'),
-            ('ARS', 'Total Events'),
-            ('ARS', 'Total PaidTix'),
-            ('ARS', 'Total GTF'),
-            ('ARS', 'Total GTV'),
-            ('ARS', 'ATV'),
-            ('ARS', 'Avg EB Perc Take Rate'),
-            ('BRL', 'Total Organizers'),
-            ('BRL', 'Total Events'),
-            ('BRL', 'Total PaidTix'),
-            ('BRL', 'Total GTF'),
-            ('BRL', 'Total GTV'),
-            ('BRL', 'ATV'),
-            ('BRL', 'Avg EB Perc Take Rate'),
+            ('ARS', 'Totals', 'Organizers'),
+            ('ARS', 'Totals', 'Events'),
+            ('ARS', 'Totals', 'PaidTix'),
+            ('ARS', 'Sales', 'GTF'),
+            ('ARS', 'Sales', 'GTV'),
+            ('ARS', 'Sales', 'ATV'),
+            ('ARS', 'Sales', 'Avg EB Take Rate'),
+            ('ARS', 'Net', 'GTF'),
+            ('ARS', 'Net', 'GTV'),
+            ('ARS', 'Net', 'ATV'),
+            ('ARS', 'Net', 'Avg EB Take Rate'),
+            ('BRL', 'Totals', 'Organizers'),
+            ('BRL', 'Totals', 'Events'),
+            ('BRL', 'Totals', 'PaidTix'),
+            ('BRL', 'Sales', 'GTF'),
+            ('BRL', 'Sales', 'GTV'),
+            ('BRL', 'Sales', 'ATV'),
+            ('BRL', 'Sales', 'Avg EB Take Rate'),
+            ('BRL', 'Net', 'GTF'),
+            ('BRL', 'Net', 'GTV'),
+            ('BRL', 'Net', 'ATV'),
+            ('BRL', 'Net', 'Avg EB Take Rate'),
         ]
         self.load_dataframes()
         response = self.client.get(URL)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.template_name[0], Dashboard.template_name)
         for elem in context_dict:
-            self.assertIn(elem[1], response.context['summarized_data'][elem[0]])
+            self.assertIn(elem[2], response.context['summarized_data'][elem[0]][elem[1]])
 
     def test_dashboard_view_returns_302_if_doesnt_have_queries(self):
         URL = reverse('dashboard')

--- a/revenue_app/utils.py
+++ b/revenue_app/utils.py
@@ -419,19 +419,38 @@ def get_summarized_data(transactions, corrections, organizer_sales, organizer_re
     for currency in currencies:
         filtered = trx[trx['currency'] == currency]
         summarized_data[currency] = {
-            'Total Organizers': filtered.eventholder_user_id.nunique(),
-            'Total Events': filtered.event_id.nunique(),
-            'Total PaidTix': filtered.PaidTix.sum(),
-            'Total GTF': round(filtered.sale__gtf_esf__epp.sum(), 2),
-            'Total GTV': round(filtered.sale__payment_amount__epp.sum(), 2),
-            'ATV': round(
-                (filtered.sale__payment_amount__epp.sum() - filtered.sale__gtf_esf__epp.sum()) / filtered.PaidTix.sum(),
-                2,
-            ),
-            'Avg EB Perc Take Rate': round(
-                filtered.sale__gtf_esf__epp.sum() / filtered.sale__payment_amount__epp.sum() * 100,
-                2,
-            ),
+            'Totals': {
+                'Organizers': filtered.eventholder_user_id.nunique(),
+                'Events': filtered.event_id.nunique(),
+                'PaidTix': filtered.PaidTix.sum(),
+            },
+            'Net': {
+                'GTF': round(filtered.sale__gtf_esf__epp.sum() + filtered.refund__gtf_epp__gtf_esf__epp.sum(), 2),
+                'GTV': round(filtered.sale__payment_amount__epp.sum() + filtered.refund__payment_amount__epp.sum(), 2),
+                'ATV': round(
+                    (filtered.sale__payment_amount__epp.sum() - filtered.sale__gtf_esf__epp.sum() +
+                     filtered.refund__payment_amount__epp.sum() - filtered.refund__gtf_epp__gtf_esf__epp.sum()
+                     ) / filtered.PaidTix.sum(),
+                    2,
+                ),
+                'Avg EB Take Rate': round(
+                    (filtered.sale__gtf_esf__epp.sum() + filtered.refund__gtf_epp__gtf_esf__epp.sum()) /
+                    (filtered.sale__payment_amount__epp.sum() + filtered.refund__payment_amount__epp.sum()) * 100,
+                    2,
+                ),
+            },
+            'Sales': {
+                'GTF': round(filtered.sale__gtf_esf__epp.sum(), 2),
+                'GTV': round(filtered.sale__payment_amount__epp.sum(), 2),
+                'ATV': round(
+                    (filtered.sale__payment_amount__epp.sum() - filtered.sale__gtf_esf__epp.sum()) / filtered.PaidTix.sum(),
+                    2,
+                ),
+                'Avg EB Take Rate': round(
+                    filtered.sale__gtf_esf__epp.sum() / filtered.sale__payment_amount__epp.sum() * 100,
+                    2,
+                ),
+            },
         }
     return summarized_data
 


### PR DESCRIPTION
- Group summary data for `Totals`, `Sales` and `Net`
- Template adapted to group data with rowcols
- Glossary updated