### PR TITLE
Add query run info to HTML and XLS

### DIFF
--- a/revenue_app/context_processors.py
+++ b/revenue_app/context_processors.py
@@ -1,0 +1,2 @@
+def query_info(request):
+    return {'query_info': request.session.get('query_info')}

--- a/revenue_app/static/revenue_app/css/base.css
+++ b/revenue_app/static/revenue_app/css/base.css
@@ -37,6 +37,12 @@ body {
   font-size: 1.5rem;
 }
 
+.navbar-text {
+  padding-left: .5rem;
+  padding-right: .5rem;
+  border-left: rgba(255,255,255,.5) 1px solid;
+}
+
 /* Content */
 
 h1 {

--- a/revenue_app/templates/revenue_app/_navbar.html
+++ b/revenue_app/templates/revenue_app/_navbar.html
@@ -1,20 +1,25 @@
 {% load static %}
 <!--Navbar -->
 <nav class="navbar navbar-expand-lg navbar-dark info-color">
-  <a href="" class="navbar-brand">Revenue
-   {% if request.session.usd.ARS %}
-      in USD (
-        {% for key, value in request.session.usd.items %}
-        {{ key }} {{value}},
-        {% endfor %}
-      )
-    {% endif %}
-  </a>
+  <a href="" class="navbar-brand">Revenue</a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
-    <ul class="navbar-nav ml-auto">
+    <ul class="navbar-nav">
+      {% if request.session.usd.ARS %}
+      <li class="navbar-text">
+        in USD (
+          {% for key, value in request.session.usd.items %}
+          {{ key }} {{value}}{% if not forloop.last %},{% endif %}
+          {% endfor %}
+        )
+      </li>
+      {% endif %}
+      {% if query_info %}
+      <li class="navbar-text">Query ran at {{ query_info.run_time }}</li>
+      <li class="navbar-text">from {{ query_info.start_date }} to {{ query_info.end_date }}</li>
+      {% endif %}
     </ul>
   </div>
 </nav>

--- a/revenue_app/tests.py
+++ b/revenue_app/tests.py
@@ -1,5 +1,8 @@
 import json
-from datetime import date
+from datetime import (
+    date,
+    datetime,
+)
 from django.template import (
     Context,
     Template,
@@ -660,6 +663,11 @@ class ViewsTest(TestCase):
         session['corrections'] = read_csv(CORRECTIONS_EXAMPLE_PATH)
         session['organizer_sales'] = read_csv(ORGANIZER_SALES_EXAMPLE_PATH)
         session['organizer_refunds'] = read_csv(ORGANIZER_REFUNDS_EXAMPLE_PATH)
+        session['query_info'] = {
+            'run_time': datetime.now(),
+            'start_date': date(2018, 8, 1),
+            'end_date': date(2018, 8, 30),
+        }
         session.save()
 
     def test_dashboard_view_returns_200(self):

--- a/settings/base.py
+++ b/settings/base.py
@@ -68,6 +68,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'revenue_app.context_processors.query_info',
             ],
         },
     },


### PR DESCRIPTION
- Display query info in the navbar
- Add context processor so every page has access to the `query_info` context data
- If there is no `query_info` (because querys have not ran), redirects to MakeQuery view
- Add title, query and currency info to the XLS
- Add query run time to CSV file name (it makes no sense to do it inside the file)
